### PR TITLE
Render links inside divs so each gets its own line

### DIFF
--- a/render.js
+++ b/render.js
@@ -10,7 +10,7 @@ function render(tokens) {
     switch(type) {
       case 'quote': return htmlEscape`<blockquote>${line.content}</blockquote>`
       case 'header': return htmlEscape`<h${line.level}>${line.content}</h${line.level}>`
-      case `link`: return htmlEscape`<a href="${line.href}">${line.content}</a>`
+      case `link`: return htmlEscape`<div><a href="${line.href}">${line.content}</a></div>`
       case `pre`: return line.alt ?
         htmlEscape`<pre><code class="language-${line.alt}">\n${line.items.join('\n')}\n</code></pre>`
         :


### PR DESCRIPTION
Gemini links are rendered as inline elements like this...

![Screen Shot 2020-10-09 at 1 43 31 PM](https://user-images.githubusercontent.com/32660718/95629788-7bb5f980-0a35-11eb-80e4-da0eed11b9d2.png)

But I believe they should be rendered as block elements like this, each on a separate line.

![Screen Shot 2020-10-09 at 1 43 43 PM](https://user-images.githubusercontent.com/32660718/95629787-7b1d6300-0a35-11eb-8ede-3f8c3cec0bfc.png)

This PR wraps each `<a>` element in a `<div>`.